### PR TITLE
Agregar la dependencia de node-jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babelify": "^6.3.0",
     "browserify": "^11.1.0",
     "express": "^4.13.3",
+    "node-jsx": "^0.13.3",
     "react": "^0.13.3",
     "react-engine": "^2.2.0",
     "react-router": "^0.13.3"


### PR DESCRIPTION
Se agregó la dependencia de node-jsx para que jale el demo a la primera
